### PR TITLE
add cython example to list of tutorials

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ These tutorials show how it is possible to write your own simulators
 using the ``tskit`` Tables API.
 
 - A simple forwards-time [Wright-Fisher](wfforward.md) simulator.
+- The simple Wright-Fisher example implemented using [Cython](wfcython.md)
 
 
 ## Advanced topics in coalescent simulation


### PR DESCRIPTION
Adds link to the Cython tutorial so that it shows up via the GH page.