### PR TITLE
edits to forward example (closes #29)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,3 +35,4 @@ sphinx:
       intersphinx_mapping:
         tskit: ["https://tskit.readthedocs.io/en/stable", null]
         msprime: ["https://tskit.dev/msprime/docs/", null]
+        pyslim: ["https://pyslim.readthedocs.io/en/stable", null]


### PR DESCRIPTION
`keep_input_roots` made this simpler. I probably ought to still mention pyslim, though, to say that "this is how SLiM & pyslim work".