### PR TITLE
Change pyslim ref to the new simplification stub

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -170,8 +170,8 @@ long terminal branches, resulting in an excess of singleton mutations.
 It can often be helpful to slim down a tree sequence so that it represents the genealogy
 of a smaller subset of the original samples. This can be done using the powerful
 {meth}`TreeSequence.simplify()<tskit.TreeSequence.simplify>` method. Here we will use it
-to reduce the number of tips in the trees we are plotting, but it has
-{ref}`many other uses<pyslim:sec_left_in_tree_sequence>`.
+to reduce the number of tips in the trees we are plotting, but the
+{ref}`Simplification tutorial<sec_simplification>` details many other uses.
 
 The {meth}`TreeSequence.draw_svg()<tskit.TreeSequence.draw_svg>` method allows us to draw
 more than one tree: either the entire tree sequence, or


### PR DESCRIPTION
Worth doing especially as builds are failing sometimes when trying to reference pyslim (e.g. https://github.com/tskit-dev/tutorials/commit/def3ea893671d324f46e7bd281d4435f056c6ab3)