### PR TITLE
Tidy up some plots

### DIFF
--- a/viz.md
+++ b/viz.md
@@ -149,7 +149,7 @@ the {ref}`sec_tskit_viz_examples`.
 
 :::{note}
 This tutorial is primarily focussed on showing a tree sequence as a set of marginal
-trees along a genome. The section titled {ref}`sec_tskit_viz_other_visualizations`
+trees along a genome. The section titled {ref}`sec_tskit_viz_other`
 provides examples of other representations of tree sequences, or the processes that
 can create them. 
 :::
@@ -936,12 +936,14 @@ HTML(html_string % (ts.draw_svg(style=css_string), ts.num_trees))
 ```
   
 
-(sec_tskit_viz_other_visualizations)=
+(sec_tskit_viz_other)=
 ## Other visualizations
 
 As well as visualizing a tree sequence as, well, a sequence of local trees, or by plotting
 {ref}`statistical summaries <tskit:sec_stats>`, other visualizations are possible, some
 of which are outlined below.
+
+(sec_tskit_viz_other_graph)=
 
 ### Graph representations
 
@@ -964,18 +966,40 @@ picture like this:
 (from [here](https://github.com/tskit-dev/tutorials/issues/43#issuecomment-787124425))
 :::
 
+(sec_tskit_viz_other_demographic)=
+
 ### Demographic processes
 
 If you are generating a tree sequence via a {ref}`Demes <msprime:sec_demography_importing>`
 model, then you can visualize a schematic of the demography itself (rather than the
-resulting tree sequence) using the [demesdraw](https://grahamgower.github.io/demesdraw/)
-software.
+resulting tree sequence) using the [DemesDraw](https://grahamgower.github.io/demesdraw/)
+software. For example, here's the plotting code to generate the
+{ref}`demography plot<sec_what_is_ancestry>` from the "{ref}`sec_what_is`" tutorial:
 
-:::{todo}
-Add a nice example e.g. 
+```{code-cell} ipython3
+:"tags": ["hide-input"]
+import matplotlib_inline
+import matplotlib.pyplot as plt
+%matplotlib inline
+matplotlib_inline.backend_inline.set_matplotlib_formats('svg')
 
-![Demesdraw example](https://grahamgower.github.io/demesdraw/_images/quickstart_6_0.svg)
-:::
+import demes
+import demesdraw
+
+def size_max(graph):
+    return max(
+        max(epoch.start_size, epoch.end_size)
+        for deme in graph.demes
+        for epoch in deme.epochs
+    )
+
+# See https://popsim-consortium.github.io/demes-docs/ for the yml spec for the file below
+graph = demes.load("data/whatis_example.yml")
+w = 1.5 * size_max(graph)
+positions = dict(Ancestral_population=0, A=-w, B=w)
+ax = demesdraw.tubes(graph, positions=positions, seed=1)
+plt.show(ax.figure)
+```
 
 ### Geography
 

--- a/what_is.md
+++ b/what_is.md
@@ -264,7 +264,9 @@ several orders of magnitude faster to process than other storage formats.
 (plot_storing_everyone)=
 
 ```{code-cell} ipython3
-:"tags": ["hide-input"]
+:"tags": ["remove-input"]
+# This cell deliberately removed (not just hidden via a toggle) as it's not helpful
+# for understanding tskit code (it's merely plotting code)
 x = data1['sample_size']
 fig, ax1 = plt.subplots(1, figsize=(10, 4))
 ax1.spines["top"].set_visible(False)
@@ -419,7 +421,9 @@ calculating [Tajima's D](https://en.wikipedia.org/wiki/Tajima%27s_D)
 
 (plot_incremental_calculation)=
 ```{code-cell} ipython3
-:"tags": ["hide-input"]
+:"tags": ["remove-input"]
+# This cell deliberately removed (not just hidden via a toggle) as it's not helpful
+# for understanding tskit code (it's merely plotting code)
 ts_time = np.array([[n,t] for s, n, t in data2[['toolkit','nsam','seconds']] if s == 'tskit'])
 ska_time = np.array([[n, t] for s, n, t in data2[['toolkit','nsam','seconds']] if s == 'allel'])
 libseq_time = np.array([[n, t] for s, n, t in data2[['toolkit','nsam','seconds']] if s == 'libseq'])

--- a/what_is.md
+++ b/what_is.md
@@ -309,7 +309,8 @@ selection, the spatial structure of populations, and the effects
 of hybridization and admixture in the past.
 
 The tree sequence in the tutorial was actually generated using a model of population
-splits and expansions as shown in the following schematic, plotted using the
+splits and expansions as shown in the following schematic,
+{ref}`plotted<sec_tskit_viz_other_demographic>` using the
 [DemesDraw](https://pypi.org/project/demesdraw/) package. Our 10 genomes were sampled
 from modern day populations A (a constant-size population) and B (a recently expanding
 one). 


### PR DESCRIPTION
Removes the ability to see the matplotlib code on the what_is page (which is irrelevant to tree sequences). Also makes the demesdraw code visible in the viz tutorial (since it might be relevant for viz, and people might want to know how it was done)