### PR TITLE
Put the msprime advances examples as sections

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -23,9 +23,11 @@ parts:
   # TODO this will be broken down more finely as we add more content
   chapters:
   - file: no_mutations
-  - file: demography
-  - file: bottlenecks
-  - file: introgression
+  - file: msprime
+    sections:
+    - file: demography
+    - file: bottlenecks
+    - file: introgression
   - file: completing-forward-sims
 - caption: Forward time simulations
   # TODO port/add forward simulation contents

--- a/bottlenecks.md
+++ b/bottlenecks.md
@@ -11,6 +11,8 @@ kernelspec:
   name: python3
 ---
 
+(sec_msprime_bottlenecks)=
+
 # Instantaneous Bottlenecks
 
 **Konrad Lohse and Jerome Kelleher**

--- a/demography.md
+++ b/demography.md
@@ -11,6 +11,8 @@ kernelspec:
   name: python3
 ---
 
+(sec_msprime_demography)=
+
 # Demography
 
 **Georgia Tsambos**

--- a/introgression.md
+++ b/introgression.md
@@ -11,6 +11,8 @@ kernelspec:
   name: python3
 ---
 
+(sec_msprime_introgression)=
+
 # Introgression 
 
 **Jerome Kelleher and Konrad Lohse**

--- a/msprime.md
+++ b/msprime.md
@@ -1,5 +1,23 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.12
+    jupytext_version: 1.9.1
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
 
-# Advanced msprime topics 
+(sec_msprime)=
 
-These are advanced topics in msprime or examples of how to 
-do some particular things in msprime.
+# Advanced {program}`msprime` topics 
+
+These are advanced topics in [msprime](https://tskit.dev/msprime) or examples of how to 
+do some particular things with it. This chapter is broken down into the following
+sections:
+
+```{tableofcontents}
+```


### PR DESCRIPTION
I think the various advanced msprime topics should be gathered together as separate paged "sections" in the tutorial book. Here's how that looks:

![Screenshot 2021-06-24 at 13 42 39](https://user-images.githubusercontent.com/4699014/123264564-0e2df880-d4f2-11eb-81fb-c27bb4418fa4.png)

That will also allow us to link direct to the "chapter" on msprime from the msprime home page, so it keeps things together nicely.