### PR TITLE
Rename "data_structures" "tables and editing"

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -212,7 +212,7 @@ up in the tree, and therefore many more mutations at higher-frequencies.
 :::{margin}
 You cannot directly edit a tree sequence; to add e.g. metadata you must edit a
 copy of the underlying tables. This is described in the
-{ref}`data structures tutorial<sec_data_structures>`.
+{ref}`Tables and editing tutorial<sec_tables_editing>`.
 :::
 
 :::{note}

--- a/terminology_and_concepts.md
+++ b/terminology_and_concepts.md
@@ -428,7 +428,7 @@ ts  # or use `print(ts)` for the plain text representation
 
 There is a separate API for dealing with a tree sequence as a collection of tables,
 which can be useful for dealing with large datasets, and is needed if you want to
-{ref}`edit<sec_data_structures_editing>` an existing tree sequence. This is covered in
-the {ref}`sec_data_structures` tutorial.
+{ref}`edit<sec_tables_editing>` an existing tree sequence. This is covered in
+the {ref}`sec_tables` tutorial.
 
 

--- a/what_is.md
+++ b/what_is.md
@@ -459,5 +459,5 @@ you might now want to continue to the next tutorial: {ref}`sec_terminology_and_c
 ## Further reading
 
 * Basic concepts: details in the {ref}`sec_terminology_and_concepts` tutorial
-* How is a tree sequence stored: details in the {ref}`sec_data_structures` tutorial
+* How is a tree sequence stored: details in the {ref}`sec_tables` tutorial
 * The offical {program}`tskit` [documentation](https://tskit.dev/tskit/docs)


### PR DESCRIPTION
I think this is less daunting a name, and the stuff about trees has now moved, so the tute is all about tables.

Also fixes #110