### PR TITLE
Fix pyslim doc URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ sphinx:
         py: ["https://docs.python.org/3", null]
         tskit: ["https://tskit.dev/tskit/docs/stable", null]
         msprime: ["https://tskit.dev/msprime/docs/stable", null]
-        pyslim: ["https://pyslim.readthedocs.io/en/stable", null]
+        pyslim: ["https://tskit.dev/pyslim/docs/stable", null]
         numpy: ["https://numpy.org/doc/stable/", null]
       myst_enable_extensions:
       - colon_fence

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+sphinx
 jupyter-book>=0.12.0
 demes
 demesdraw


### PR DESCRIPTION
Fixes #159 
Wasn't sphinx, but the pyslim docs moving without an object.inv redirect. 