### PR TITLE
Mention the words "ancestral" and "genealogy" at the top

### DIFF
--- a/what_is.md
+++ b/what_is.md
@@ -72,11 +72,11 @@ def create_notebook_data():
 
 # What is a tree sequence?
 
-A *succinct tree sequence*, or "tree sequence" for short, represents the evolutionary
+A *succinct tree sequence*, or "tree sequence" for short, represents the ancestral
 relationships between a set of DNA sequences. Tree sequences are based on fundamental
 biological principles of inheritance, DNA duplication, and recombination; they can be
-created by [simulation](https://tskit.dev/software/#simulate) or by
-[inferring relationships from empirical DNA data](https://tskit.dev/software/#infer).
+created by [evolutionary simulation](https://tskit.dev/software/#simulate) or by
+[inferring genealogies from empirical DNA data](https://tskit.dev/software/#infer).
 
 :::{margin} Key point
 Tree sequences are used to encode and analyse large genetic datasets


### PR DESCRIPTION
A bit trivial, but pretty much the first page that people will go to when trying to lean what a tree sequence is is "what is a tree sequence". We should mention the words "ancestry" and "genealogy" in the first para, so that ARG-affectionados will stay reading.

It's good to keep "evolution" in the first para too, as that's what the phylogeneticists (and members of other research field) will be looking for, so I tried to squeeze that in to the "simulation" part, but maybe it could be done better another way.

