### PR TITLE
Update requirements for numpy 2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,12 +35,12 @@ sphinx:
     config:
       html_theme: sphinx_book_theme
       html_theme_options:
-        pygment_dark_style: monokai
+        pygments_dark_style: monokai
       todo_include_todos: true
       intersphinx_mapping:
         py: ["https://docs.python.org/3", null]
         tskit: ["https://tskit.dev/tskit/docs/stable", null]
-        tszip: ["https://tszip.readthedocs.io/en/stable/", null]
+        tszip: ["https://tskit.dev/tszip/docs/latest/", null]
         msprime: ["https://tskit.dev/msprime/docs/stable", null]
         pyslim: ["https://tskit.dev/pyslim/docs/stable", null]
         numpy: ["https://numpy.org/doc/stable/", null]

--- a/args.md
+++ b/args.md
@@ -312,7 +312,7 @@ difference between some classical ARG formulations, and the ARG formulation
 used in `tskit`. Classically, nodes in an ARG are taken to represent _events_
 (specifically, "common ancestor", "recombination", and "sampling" events),
 and genomic regions of inheritance are encoded by storing a specific breakpoint location on
-each recombination node. In contrast, [nodes](tskit:sec_data_model_definitions_node) in a `tskit`
+each recombination node. In contrast, {ref}`nodes<tskit:sec_data_model_definitions_node>` in a `tskit`
 ARG correspond to _genomes_. More crucially, inherited regions are defined by intervals
 stored on *edges* (via the {attr}`~Edge.left` and  {attr}`~Edge.right` properties),
 rather than on nodes. Here, for example, is the edge table from our ARG:

--- a/counting_topologies.md
+++ b/counting_topologies.md
@@ -51,7 +51,7 @@ def create_notebook_data():
 This tutorial is intended to be a gentle introduction to the combinatorial
 treatment of tree topologies in `tskit`. For a more formal introduction,
 see the {ref}`sec_combinatorics` section of the
-[official `tskit` documentation](tskit:sec_introduction).
+official `tskit` {ref}`documentation<tskit:sec_introduction>`.
 
 The *topology* of a single tree is the term used to describe the branching pattern,
 regardless of the lengths of the branches. For example, both trees below have the

--- a/requirements-CI.txt
+++ b/requirements-CI.txt
@@ -1,16 +1,16 @@
 git+https://github.com/tskit-dev/tsconvert@e99c837e4e26ccbf4f480a4c48626338eeff7dc3
 demes==0.2.3
 demesdraw==0.4.0
-jupyter-book==0.15.1
+jupyter-book==1.0.2
 jupyter-cache==0.6.1
-msprime==1.2.0
-networkx==3.1
-pandas==2.1.1
-pygraphviz==1.10
-scikit-allel==1.3.7
+msprime==1.3.2
+networkx==3.3
+pandas==2.2.2
+pygraphviz==1.13
+scikit-allel==1.3.8
 stdpopsim==0.2.0
 tqdm==4.66.3
-tskit==0.5.5
+tskit==0.5.8
 tskit_arg_visualizer==0.0.1
-tszip==0.2.2
+tszip==0.2.4
 jsonschema==4.18.6 # Pinned due to 4.19 "AttributeError module jsonschema has no attribute _validators"


### PR DESCRIPTION
This won't work until scikit-allel is numpy 2.0 compatible. See https://github.com/cggh/scikit-allel/issues/415

Also note that the tszip docs are linked to the `latest` not `stable` version. See https://github.com/tskit-dev/tszip/issues/67#issuecomment-2222477153