### PR TITLE
Allow tutes to work with stdpopsim3

### DIFF
--- a/popgen.md
+++ b/popgen.md
@@ -94,7 +94,7 @@ large genomic datasets.
 
 Several simulation tools output tree sequences. Below we use the
 standard library for population genetic simulation models
-([stdpopsim](https://popsim-consortium.github.io/)) to generate a model of
+([stdpopsim](https://popsim-consortium.github.io/stdpopsim-docs/)) to generate a model of
 *Homo sapiens*, in which African, Eurasian,
 and Asian populations combine to generate a mixed American population. We can use the
 [demesdraw](https://pypi.org/project/demesdraw/) package to plot a schematic of the
@@ -107,7 +107,7 @@ import demesdraw
 from matplotlib import pyplot as plt
 
 species = stdpopsim.get_species("HomSap")
-model = species.get_demographic_model("AmericanAdmixture_4B11")
+model = species.get_demographic_model("AmericanAdmixture_4B18")
 
 # Plot a schematic of the model
 demesdraw.tubes(model.model.to_demes(), ax=plt.gca(), seed=1, log_time=True)
@@ -125,7 +125,7 @@ succinct tree sequence named `ts`:
 contig = species.get_contig("chr1", mutation_rate=model.mutation_rate, right=20_000)
 samples = {"AFR": 4, "EUR": 4, "ASIA": 4, "ADMIX": 4} # 16 diploid samples
 engine = stdpopsim.get_engine("msprime")
-ts = engine.simulate(model, contig, samples, seed=9)
+ts = engine.simulate(model, contig, samples, seed=9).trim()  # trim to first 20kb simulated
 print(f"Simulated a tree sequence of {ts.num_samples} haploid genomes:")
 print(f"{ts.num_sites} variable sites over {ts.sequence_length} base pairs")
 ```

--- a/requirements-CI.txt
+++ b/requirements-CI.txt
@@ -9,7 +9,7 @@ numpy==1.26.4
 pandas==2.2.2
 pygraphviz==1.13
 scikit-allel==1.3.8
-stdpopsim==0.2.0
+stdpopsim==0.3.0
 tqdm==4.66.3
 tskit==0.5.8
 tskit_arg_visualizer==0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ networkx
 pandas
 pygraphviz
 scikit-allel
-stdpopsim
+stdpopsim>=0.3
 tqdm
 tskit>=0.5.4
 tskit_arg_visualizer


### PR DESCRIPTION
Mainly broken because specifying e.g. `right=20_000` does not change the sequence length. To get a shorter chromosome, you also need to `.trim()` the resulting ts.